### PR TITLE
feat: support LinkML field names with spaces.

### DIFF
--- a/platformics/codegen/lib/linkml_wrappers.py
+++ b/platformics/codegen/lib/linkml_wrappers.py
@@ -33,11 +33,11 @@ class FieldWrapper:
 
     @cached_property
     def name(self) -> str:
-        return self.wrapped_field.name
+        return self.wrapped_field.name.replace(" ", "_")
 
     @cached_property
     def camel_name(self) -> str:
-        return strcase.to_lower_camel(self.wrapped_field.name)
+        return strcase.to_lower_camel(self.name)
 
     @cached_property
     def multivalued(self) -> str:

--- a/platformics/codegen/lib/linkml_wrappers.py
+++ b/platformics/codegen/lib/linkml_wrappers.py
@@ -25,7 +25,7 @@ class FieldWrapper:
         """
         Error if a property doesn't exist
         """
-        raise NotImplementedError(f"please define field property {attr}")
+        raise NotImplementedError(f"please define field property {self.wrapped_field.name}.{attr}")
 
     @cached_property
     def identifier(self) -> str:
@@ -207,7 +207,7 @@ class EntityWrapper:
 
     # Blow up if a property doesn't exist
     def __getattr__(self, attr: str) -> str:
-        raise NotImplementedError(f"please define entity property {attr}")
+        raise NotImplementedError(f"please define entity property {self.wrapped_class.name}.{attr}")
 
     @cached_property
     def name(self) -> str:

--- a/platformics/codegen/templates/api/types/class_name.py.j2
+++ b/platformics/codegen/templates/api/types/class_name.py.j2
@@ -62,7 +62,7 @@ from support.enums import
 {%- endfor %}
 
 
-E = typing.TypeVar("E", base_db.File, base_db.Entity)
+E = typing.TypeVar("E", base_db.File, db.{{ cls.name }})
 T = typing.TypeVar("T")
 
 if TYPE_CHECKING:
@@ -507,7 +507,7 @@ async def create_{{ cls.snake_name }}(
     cerbos_client: CerbosClient = Depends(get_cerbos_client),
     principal: Principal = Depends(require_auth_principal),
     is_system_user: bool = Depends(is_system_user),
-) -> db.Entity:
+) -> db.{{ cls.name }}:
     """
     Create a new {{ cls.name }} object. Used for mutations (see api/mutations.py).
     """
@@ -567,7 +567,7 @@ async def update_{{ cls.snake_name }}(
     cerbos_client: CerbosClient = Depends(get_cerbos_client),
     principal: Principal = Depends(require_auth_principal),
     is_system_user: bool = Depends(is_system_user),
-) -> Sequence[db.Entity]:
+) -> Sequence[db.{{ cls.name }}]:
     """
     Update {{ cls.name }} objects. Used for mutations (see api/mutations.py).
     """
@@ -640,7 +640,7 @@ async def delete_{{ cls.snake_name }}(
     session: AsyncSession = Depends(get_db_session, use_cache=False),
     cerbos_client: CerbosClient = Depends(get_cerbos_client),
     principal: Principal = Depends(require_auth_principal),
-) -> Sequence[db.Entity]:
+) -> Sequence[db.{{ cls.name }}]:
     """
     Delete {{ cls.name }} objects. Used for mutations (see api/mutations.py).
     """

--- a/test_app/conftest.py
+++ b/test_app/conftest.py
@@ -231,6 +231,7 @@ def overwrite_api(api: FastAPI, async_db: AsyncDB) -> None:
 def raise_exception() -> str:
     raise Exception("Unexpected error")
 
+
 # Subclass Query with an additional field to test Exception handling.
 @strawberry.type
 class MyQuery(Query):
@@ -238,6 +239,7 @@ class MyQuery(Query):
     def uncaught_exception(self) -> str:
         # Trigger an AttributeException
         return self.kaboom  # type: ignore
+
 
 @pytest_asyncio.fixture()
 async def api_test_schema(async_db: AsyncDB) -> FastAPI:

--- a/test_app/schema/schema.yaml
+++ b/test_app/schema/schema.yaml
@@ -293,6 +293,8 @@ classes:
         annotations:
           minimum_length: 3
           maximum_length: 8
+      field with spaces:
+        range: string
       regex_format_check:
         range: string
         pattern: '\d{3}-\d{2}-\d{4}'

--- a/test_app/tests/test_field_with_spaces.py
+++ b/test_app/tests/test_field_with_spaces.py
@@ -1,0 +1,43 @@
+"""
+Test basic queries and mutations
+"""
+
+import datetime
+import pytest
+from platformics.database.connect import SyncDB
+from conftest import GQLTestClient, SessionStorage
+from test_infra.factories.constraint_checked_type import ConstraintCheckedTypeFactory
+
+date_now = datetime.datetime.now()
+
+
+@pytest.mark.asyncio
+async def test_field_with_spaces(
+    sync_db: SyncDB,
+    gql_client: GQLTestClient,
+) -> None:
+    """
+    Test that we can only fetch samples from the database that we have access to
+    """
+    user_id = 12345
+    project_id = 123
+
+    # Create mock data
+    with sync_db.session() as session:
+        SessionStorage.set_session(session)
+        cct = ConstraintCheckedTypeFactory.create(
+            owner_user_id=user_id,
+            collection_id=project_id,
+        )
+
+    # Fetch the row via gql
+    query = """
+        query MyQuery {
+            constraintCheckedTypes {
+                id,
+                fieldWithSpaces
+            }
+        }
+    """
+    output = await gql_client.query(query, user_id=user_id, member_projects=[project_id])
+    assert cct.field_with_spaces == output["data"]["constraintCheckedTypes"][0]["fieldWithSpaces"]

--- a/test_app/tests/test_field_with_spaces.py
+++ b/test_app/tests/test_field_with_spaces.py
@@ -41,3 +41,4 @@ async def test_field_with_spaces(
     """
     output = await gql_client.query(query, user_id=user_id, member_projects=[project_id])
     assert cct.field_with_spaces == output["data"]["constraintCheckedTypes"][0]["fieldWithSpaces"]
+    assert output["data"]["constraintCheckedTypes"][0]["fieldWithSpaces"]


### PR DESCRIPTION
Fixes #66 

This adds support for LinkML fields with spaces. The spaces are converted to underscores when we write out `snake_case` field names, and then get converted to `camelCase` properly at word boundaries (basically just in the GQL interface)