### PR TITLE
[DO NOT MERGE] Demonstrate how to allow anonymous access to data.

### DIFF
--- a/test_app/main.py
+++ b/test_app/main.py
@@ -8,6 +8,9 @@ from platformics.api.setup import get_app, get_strawberry_config
 from platformics.api.core.error_handler import HandleErrors
 from platformics.settings import APISettings
 from database import models
+from platformics.api.core.deps import get_auth_principal, require_auth_principal
+from cerbos.sdk.model import Principal
+from fastapi import Depends
 
 from api.mutations import Mutation
 from api.queries import Query
@@ -18,6 +21,27 @@ schema = strawberry.Schema(query=Query, mutation=Mutation, config=get_strawberry
 
 # Create and run app
 app = get_app(settings, schema, models)
+
+
+def override_auth_principal(principal: Principal = Depends(get_auth_principal)):
+    if principal:
+        return principal
+
+    # Create an anonymous auth scope if we don't have a logged in user!
+    return Principal(
+        "anonymous",
+        roles=["user"],
+        attr={
+            "user_id": 0,
+            "owner_projects": [],
+            "member_projects": [],
+            "viewer_projects": [444],
+            "service_identity": [],
+        },
+    )
+
+
+app.dependency_overrides[require_auth_principal] = override_auth_principal
 
 if __name__ == "__main__":
     config = uvicorn.Config("main:app", host="0.0.0.0", port=9008, log_level="info")

--- a/test_app/main.py
+++ b/test_app/main.py
@@ -35,8 +35,9 @@ def override_auth_principal(principal: Principal = Depends(get_auth_principal)):
             "user_id": 0,
             "owner_projects": [],
             "member_projects": [],
-            "viewer_projects": [444],
             "service_identity": [],
+            # This value can be read from a secret or env var or whatever. Just hardcoded here for brevity.
+            "viewer_projects": [444],
         },
     )
 


### PR DESCRIPTION
This is a **proposal** for how Platformics can support making some data public.
It shouldn't be merged into this repo, but I'm asking for *feedback* about whether this is an acceptable solution for #73 

Currently our codegen [adds a dependency](https://github.com/chanzuckerberg/platformics/blob/main/platformics/codegen/templates/api/types/class_name.py.j2#L417) to every resolver called `require_auth_principal`, which essentially checks for a valid auth token and raises an exception if there isn't one available:
https://github.com/chanzuckerberg/platformics/blob/main/platformics/api/core/deps.py#L107-L112

This is OK for API's that only need to be accessible to authenticated users, but it falls over when an API also needs to be accessible to the public.

However, FastAPI provides [a way to override dependencies](https://fastapi.tiangolo.com/advanced/testing-dependencies/), and `main.py` is controlled by application authors (that is, it isn't code-gen'd!) so we can manipulate the dependencies of our FastAPI application and override platformics default behaviors.

In this example, we're overriding `require_auth_principal` to return a "dummy" anonymous principal that only has read access to certain collections that we deem to be publicly accessible.

Is this a reasonable workaround to allow public access?