### PR TITLE
[Do not merge] Example of adding hooks to mutation

### DIFF
--- a/platformics/api/core/strawberry_extensions.py
+++ b/platformics/api/core/strawberry_extensions.py
@@ -48,6 +48,14 @@ class RegisteredPlatformicsPlugins:
         return cls.plugins.get(f"{callback_order}:{type}:{action}")
 
 
+def register_plugin(callback_order: str, type: str, action: str) -> Callable[..., Callable[..., Any]]:
+    def decorator_register(func: Callable[..., Any]) -> Callable[..., Any]:
+        RegisteredPlatformicsPlugins.register(callback_order, type, action, func)
+        return func
+
+    return decorator_register
+
+
 class PlatformicsPluginExtension(FieldExtension):
     def __init__(self, type: str, action: str) -> None:
         self.type = type

--- a/platformics/codegen/templates/api/types/class_name.py.j2
+++ b/platformics/codegen/templates/api/types/class_name.py.j2
@@ -40,7 +40,7 @@ from fastapi import Depends
 from platformics.api.core.errors import PlatformicsError
 from platformics.api.core.deps import get_cerbos_client, get_db_session, require_auth_principal, is_system_user
 from platformics.api.core.query_input_types import aggregator_map, orderBy, EnumComparators, DatetimeComparators, IntComparators, FloatComparators, StrComparators, UUIDComparators, BoolComparators
-from platformics.api.core.strawberry_extensions import DependencyExtension
+from platformics.api.core.strawberry_extensions import DependencyExtension, PlatformicsPluginExtension
 from platformics.security.authorization import CerbosAction, get_resource_query
 from sqlalchemy import inspect
 from sqlalchemy.engine.row import RowMapping
@@ -500,7 +500,7 @@ async def resolve_{{ cls.plural_snake_name }}_aggregate(
     return aggregate_output
 
 {%- if cls.create_fields %}
-@strawberry.mutation(extensions=[DependencyExtension()])
+@strawberry.mutation(extensions=[DependencyExtension(), PlatformicsPluginExtension("{{ cls.snake_name }}", "create")])
 async def create_{{ cls.snake_name }}(
     input: {{ cls.name }}CreateInput,
     session: AsyncSession = Depends(get_db_session, use_cache=False),
@@ -559,7 +559,7 @@ async def create_{{ cls.snake_name }}(
 
 
 {%- if cls.mutable_fields %}
-@strawberry.mutation(extensions=[DependencyExtension()])
+@strawberry.mutation(extensions=[DependencyExtension(), PlatformicsPluginExtension("{{ cls.snake_name }}", "update")])
 async def update_{{ cls.snake_name }}(
     input: {{ cls.name }}UpdateInput,
     where: {{ cls.name }}WhereClauseMutations,
@@ -634,7 +634,7 @@ async def update_{{ cls.snake_name }}(
 {%- endif %}
 
 
-@strawberry.mutation(extensions=[DependencyExtension()])
+@strawberry.mutation(extensions=[DependencyExtension(), PlatformicsPluginExtension("{{ cls.snake_name }}", "delete")])
 async def delete_{{ cls.snake_name }}(
     where: {{ cls.name }}WhereClauseMutations,
     session: AsyncSession = Depends(get_db_session, use_cache=False),

--- a/test_app/conftest.py
+++ b/test_app/conftest.py
@@ -231,6 +231,7 @@ def overwrite_api(api: FastAPI, async_db: AsyncDB) -> None:
 def raise_exception() -> str:
     raise Exception("Unexpected error")
 
+
 # Subclass Query with an additional field to test Exception handling.
 @strawberry.type
 class MyQuery(Query):
@@ -238,6 +239,7 @@ class MyQuery(Query):
     def uncaught_exception(self) -> str:
         # Trigger an AttributeException
         return self.kaboom  # type: ignore
+
 
 @pytest_asyncio.fixture()
 async def api_test_schema(async_db: AsyncDB) -> FastAPI:

--- a/test_app/main.py
+++ b/test_app/main.py
@@ -9,7 +9,7 @@ from platformics.api.setup import get_app, get_strawberry_config
 from platformics.api.core.error_handler import HandleErrors
 from platformics.settings import APISettings
 from database import models
-from platformics.api.core.strawberry_extensions import RegisteredPlatformicsPlugins
+from platformics.api.core.strawberry_extensions import register_plugin
 
 from api.mutations import Mutation
 from api.queries import Query
@@ -17,12 +17,11 @@ from typing import Any
 from strawberry.types import Info
 
 
+@register_plugin("before", "sample", "create")
 def validate_sample_name(source: Any, info: Info, **kwargs: SampleCreateInput) -> None:
     if kwargs["input"].name == "foo":
         raise ValueError("Sample name cannot be 'foo'")
 
-
-RegisteredPlatformicsPlugins.register("before", "sample", "create", validate_sample_name)
 
 settings = APISettings.model_validate({})  # Workaround for https://github.com/pydantic/pydantic/issues/3753
 schema = strawberry.Schema(query=Query, mutation=Mutation, config=get_strawberry_config(), extensions=[HandleErrors()])

--- a/test_app/main.py
+++ b/test_app/main.py
@@ -4,13 +4,25 @@ Launch the GraphQL server.
 
 import strawberry
 import uvicorn
+from api.types.sample import SampleCreateInput
 from platformics.api.setup import get_app, get_strawberry_config
 from platformics.api.core.error_handler import HandleErrors
 from platformics.settings import APISettings
 from database import models
+from platformics.api.core.strawberry_extensions import RegisteredPlatformicsPlugins
 
 from api.mutations import Mutation
 from api.queries import Query
+from typing import Any
+from strawberry.types import Info
+
+
+def validate_sample_name(source: Any, info: Info, **kwargs: SampleCreateInput) -> None:
+    if kwargs["input"].name == "foo":
+        raise ValueError("Sample name cannot be 'foo'")
+
+
+RegisteredPlatformicsPlugins.register("before", "sample", "create", validate_sample_name)
 
 settings = APISettings.model_validate({})  # Workaround for https://github.com/pydantic/pydantic/issues/3753
 schema = strawberry.Schema(query=Query, mutation=Mutation, config=get_strawberry_config(), extensions=[HandleErrors()])


### PR DESCRIPTION
Example of adding hooks to create, update, delete mutations. This example validates the name of a sample before it is created.

Right now a before callback receives three args (inputs to the mutation) and the after callback receives four (inputs to the mutation + the result). This is weird.