### PR TITLE
feat: add tags to docker image with release-please

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+      - ninabernick/semver
+  workflow_dispatch:
 
 jobs:
   build-and-push:
@@ -37,6 +39,16 @@ jobs:
 
     - name: Build with Poetry
       run: make build-wheel
+    
+    - name: Release Please Action
+      id: release
+      uses: google-github-actions/release-please-action@v4
+      with:
+        release-type: simple
+        token: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Print version
+      run: echo "Calculated version is ${{ steps.release.outputs.version }}"
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v2
@@ -44,4 +56,5 @@ jobs:
         context: .
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}:latest
+          ghcr.io/${{ github.repository }}-test:latest
+          ghcr.io/${{ github.repository }}-test:${{ steps.release.outputs.version }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -51,9 +51,9 @@ jobs:
       id: docker_tag
       run: |
         if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-          echo "::set-output name=tag::${{ steps.release.outputs.version }}"
+          echo "tag=${{ steps.release.outputs.version }}" >> $GITHUB_ENV
         else
-          echo "::set-output name=tag::latest"
+          echo "tag=latest" >> $GITHUB_ENV
         fi
 
     - name: Build and push Docker image
@@ -62,4 +62,4 @@ jobs:
         context: .
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}-test:${{ steps.docker_tag.outputs.version }}
+          ghcr.io/${{ github.repository }}-test:${{ env.tag }}

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ninabernick/semver
   workflow_dispatch:
 
 jobs:
@@ -47,14 +46,6 @@ jobs:
         release-type: simple
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Determine Docker tag
-      id: docker_tag
-      run: |
-        if [ "${{ github.ref }}" == "refs/heads/main" ]; then
-          echo "tag=${{ steps.release.outputs.version }}" >> $GITHUB_ENV
-        else
-          echo "tag=latest" >> $GITHUB_ENV
-        fi
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
@@ -62,4 +53,5 @@ jobs:
         context: .
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}-test:${{ env.tag }}
+          ghcr.io/${{ github.repository }}:${{ steps.release.outputs.version }}
+          ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -1,9 +1,9 @@
 name: Build and push docker image
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: 
+      - published
   workflow_dispatch:
 
 jobs:
@@ -38,14 +38,6 @@ jobs:
 
     - name: Build with Poetry
       run: make build-wheel
-    
-    - name: Release Please Action
-      id: release
-      uses: googleapis/release-please-action@v4
-      with:
-        release-type: simple
-        token: ${{ secrets.GITHUB_TOKEN }}
-
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v6
@@ -53,5 +45,5 @@ jobs:
         context: .
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}:${{ steps.release.outputs.version }}
+          ghcr.io/${{ github.repository }}:${{ github.event.release.tag_name }}
           ghcr.io/${{ github.repository }}:latest

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -21,6 +21,7 @@ jobs:
     - name: install poetry
       run: |
         python -m pip install --no-cache-dir poetry==1.8 supervisor
+        poetry self add "poetry-dynamic-versioning[plugin]"
 
     - name: set up docker
       run: |

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -42,7 +42,7 @@ jobs:
     
     - name: Release Please Action
       id: release
-      uses: google-github-actions/release-please-action@v4
+      uses: googleapis/release-please-action@v4
       with:
         release-type: simple
         token: ${{ secrets.GITHUB_TOKEN }}
@@ -57,7 +57,7 @@ jobs:
         fi
 
     - name: Build and push Docker image
-      uses: docker/build-push-action@v2
+      uses: docker/build-push-action@v6
       with:
         context: .
         push: true

--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -47,8 +47,14 @@ jobs:
         release-type: simple
         token: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Print version
-      run: echo "Calculated version is ${{ steps.release.outputs.version }}"
+    - name: Determine Docker tag
+      id: docker_tag
+      run: |
+        if [ "${{ github.ref }}" == "refs/heads/main" ]; then
+          echo "::set-output name=tag::${{ steps.release.outputs.version }}"
+        else
+          echo "::set-output name=tag::latest"
+        fi
 
     - name: Build and push Docker image
       uses: docker/build-push-action@v2
@@ -56,5 +62,4 @@ jobs:
         context: .
         push: true
         tags: |
-          ghcr.io/${{ github.repository }}-test:latest
-          ghcr.io/${{ github.repository }}-test:${{ steps.release.outputs.version }}
+          ghcr.io/${{ github.repository }}-test:${{ steps.docker_tag.outputs.version }}

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -1,0 +1,15 @@
+name: Ensure all PRs have conventional commit titles
+on:
+  pull_request:
+    types:
+      - edited
+      - opened
+      - synchronize
+      - reopened
+
+jobs:
+  conventional_commit_title:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: chanzuckerberg/github-actions/.github/actions/conventional-commits@main

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,23 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+      - ninabernick/semver
+
+jobs:
+  release:
+    name: Run release-please
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Run release-please
+      uses: google-github-actions/release-please-action@v3
+      with:
+        release-type: python
+        token: ${{ secrets.GITHUB_TOKEN }}
+        bump-minor-pre-major: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - ninabernick/semver
 
 jobs:
   release:

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,8 +6,8 @@ RUN apt update && \
 
 COPY requirements.txt .
 RUN pip install -r requirements.txt
-COPY dist/platformics-0.1.0-py3-none-any.whl /tmp/platformics-0.1.0-py3-none-any.whl
-RUN cd /tmp/ && pip install platformics-0.1.0-py3-none-any.whl && rm -rf /tmp/*.whl
+COPY dist /tmp/dist
+RUN cd /tmp/dist && pip install *.whl && rm -rf /tmp/*.whl
 
 RUN mkdir -p /app
 WORKDIR /app

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ The libraries and tools that make Platformics work:
 ## Roadmap
 - [ ] Plugin hooks to add business logic to generated GQL resolvers
 - [ ] Support arbitrary class inheritance hierarchies
+- [ ] Package and publish to PyPI
 
 ## How to set up your own platformics API
 1. Copy the test_app boilerplate code to your own repository.
@@ -42,6 +43,9 @@ The libraries and tools that make Platformics work:
 3. Run `make build` and then `make init` to build and run your own GraphQL API service.
 4. Browse to http://localhost:9009/graphql to interact with your api!
 5. Run `make token` to generate an authorization token that you can use to interact with the API. The `make` target copies the necessary headers to the system clipboard. Paste the token into the `headers` section at the bottom of the GraphQL explorer API
+
+## Versioning platformics
+Right now, platformics is used in downstream applications by using the platformics image as the base Docker image. To select a version of platformics, add the appropriate version tags to the docker image.
 
 ## Iterating on your schema
 1. Make changes to `schema/schema.yml`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "platformics"
-version = "0.1.0"
+version = "0.0.0" # placeholder version
 description = "Platformics bio entities framework"
 authors = ["CZI Infectious Disease Team <help@czid.org>"]
 license = "MIT License"
@@ -51,8 +51,11 @@ sqlalchemy_utils = "^0.41.1"
 strawberry-graphql = "^0.217.0"
 
 [build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"
+
+[tool.poetry-dynamic-versioning]
+enable = true
 
 [tool.black]
 line-length = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.poetry]
 name = "platformics"
-version = "0.0.0" # placeholder version
+# placeholder version that will be replace by poetry-dynamic-versioning
+version = "0.0.0"
 description = "Platformics bio entities framework"
 authors = ["CZI Infectious Disease Team <help@czid.org>"]
 license = "MIT License"
@@ -52,6 +53,7 @@ strawberry-graphql = "^0.217.0"
 
 [build-system]
 requires = ["poetry-core", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+# a wrapper for poetry.core.masonry.api
 build-backend = "poetry_dynamic_versioning.backend"
 
 [tool.poetry-dynamic-versioning]


### PR DESCRIPTION
Use release-please to assign versions, create changelog, and tag the docker image with the appropriate version. Enables downstream versioning of platformics in apps: users can add tags to the base platformics docker image used in `test_app/Dockerfile`
When a PR is merged to main, the release please workflow will determine the current version and add to/open release PR. 
When the release PR is merged and a release is created, the we push a docker image with the release tag and the latest tag.

The version in `pyproject.toml` is a placeholder, the version is dynamically managed by `poetry-dynamic-versioning` using the release tags.


Notes:
- enforces [conventional commit messages](https://www.conventionalcommits.org/en/v1.0.0/#summary): `fix` = patch, `feat` = minor, `fix!`, `feat!`, `refactor!` etc = breaking change (needs `!`)


Testing:
- tested by running release please workflow on my branch, which generated release PR. Won't be able to test release build + push until release PR is merged