### PR TITLE
fix: specify when build and test should run

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -2,6 +2,11 @@ name: Build and test
 
 on:
   pull_request:
+    types:
+      - edited
+      - opened
+      - synchronize
+      - reopened
   push:
     branches: [main]
 


### PR DESCRIPTION
Build and test was not running for release PR but was blocking its merge.