### PR TITLE
fix: use shared infra github token for release please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -8,7 +8,7 @@ concurrency:
 name: release-please
 jobs:
   release-please:
-    runs-on: [ARM64, self-hosted, Linux]
+    runs-on: ubuntu-latest
     steps:
       # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
       # For why we need to generate a token and not use the default

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,29 +1,27 @@
 name: Release Please
-
 on:
   push:
     branches:
       - main
-
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+name: release-please
 jobs:
-  release:
-    name: Run release-please
-    runs-on: ubuntu-latest
-
+  release-please:
+    runs-on: [ARM64, self-hosted, Linux]
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v4
+      # See https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow
+      # For why we need to generate a token and not use the default
+      - name: Generate token
+        id: generate_token
+        uses: tibdex/github-app-token@v2
+        with:
+          app_id: ${{ secrets.CZI_RELEASE_PLEASE_APP_ID }}
+          private_key: ${{ secrets.CZI_RELEASE_PLEASE_PK }}
 
-    - name: Generate token
-      id: generate_token
-      uses: chanzuckerberg/github-app-token@v1.1.4
-      with:
-        app_id: ${{ secrets.CZI_RELEASE_PLEASE_APP_ID }}
-        private_key: ${{ secrets.CZI_RELEASE_PLEASE_PK }}
-
-    - name: Run release-please
-      uses: google-github-actions/release-please-action@v3
-      with:
-        release-type: python
-        token: ${{ steps.generate_token.outputs.token }}
-        bump-minor-pre-major: true
+      - name: release please
+        uses: googleapis/release-please-action@v4
+        id: release
+        with:
+          token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,4 +1,3 @@
-name: Release Please
 on:
   push:
     branches:
@@ -24,4 +23,6 @@ jobs:
         uses: googleapis/release-please-action@v4
         id: release
         with:
+          release-type: python
           token: ${{ steps.generate_token.outputs.token }}
+          bump-minor-pre-major: true

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,9 +14,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v4
 
+    - name: Generate token
+      id: generate_token
+      uses: chanzuckerberg/github-app-token@v1.1.4
+      with:
+        app_id: ${{ secrets.CZI_RELEASE_PLEASE_APP_ID }}
+        private_key: ${{ secrets.CZI_RELEASE_PLEASE_PK }}
+
     - name: Run release-please
       uses: google-github-actions/release-please-action@v3
       with:
         release-type: python
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ steps.generate_token.outputs.token }}
         bump-minor-pre-major: true


### PR DESCRIPTION
You can't trigger a second workflow from a first workflow that used the repo's `GITHUB_TOKEN` (see [here](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow)). Use central infra's tokens instead.