### PR TITLE
chore: minor improvements

### DIFF
--- a/platformics/codegen/templates/database/migrations/env.py.j2
+++ b/platformics/codegen/templates/database/migrations/env.py.j2
@@ -43,6 +43,8 @@ def run_migrations_offline() -> None:
     )
 
     with context.begin_transaction():
+        context.get_context()._ensure_version_table()  # pylint: disable=protected-access
+        connection.execute(sa.sql.text("LOCK TABLE alembic_version IN ACCESS EXCLUSIVE MODE"))
         context.run_migrations()
 
 

--- a/platformics/codegen/templates/support/enums.py.j2
+++ b/platformics/codegen/templates/support/enums.py.j2
@@ -13,6 +13,7 @@ import enum
 @strawberry.enum
 class {{enum.name}}(enum.Enum):
     {%- for value in enum.permissible_values %}
-    {{value}} = "{{value}}"
+    {#- SQLAlchemy freaks out about spaces in enum values :'( #}
+    {{value | regex_replace('[^0-9A-Za-z]', '_') }} = "{{value | regex_replace('[^0-9A-Za-z]', '_') }}"
     {%- endfor %}
 {%- endfor %}


### PR DESCRIPTION
This PR adds two small fixes:
- Wrap migration runs in a DB lock. This ensures that if the app runs migrations via a k8s `initContainer` definition, only one pod will be able to run migrations and we won't run into concurrency problems.
- SQLAlchemy doesn't handle enum values with spaces in them very well. This updates codegen to convert any non-alphanumeric characters to underscores