### PR TITLE
feat: support default values for object create/update.

### DIFF
--- a/platformics/codegen/templates/database/models/class_name.py.j2
+++ b/platformics/codegen/templates/database/models/class_name.py.j2
@@ -16,6 +16,7 @@ from platformics.database.models.base import Entity
 from sqlalchemy import ForeignKey, String, Float, Integer, Enum, Boolean, DateTime
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.sql import func
 {%- for field in cls.enum_fields %}
     {%- if loop.first %}
 from support.enums import
@@ -45,23 +46,47 @@ class {{cls.name}}(Entity):
     __tablename__ = "{{ cls.snake_name }}"
     __mapper_args__ = {"polymorphic_identity": __tablename__, "polymorphic_load": "inline"}
 
+{% macro getStandardParameters(field) -%}
+    nullable={{ "False" if field.required else "True"}}
+    {%- if field.default_value%}, default={{field.default_value}}{%- endif %}
+    {%- if field.server_default%}, server_default={{field.server_default}}{%- endif %}
+    {%- if field.default_callable%}, default={{field.default_callable}}{%- endif %}
+    {%- if field.indexed%}, index=True{%- endif %}
+    {%- if field.onupdate%}, onupdate={{field.onupdate}}{%- endif %}
+    {%- if field.auto_increment%}, autoincrement=True{%- endif %}
+    {%- if field.identifier %}, primary_key=True{%- endif %}
+{%- endmacro %}
+
+{# Map of LinkML field types to SQLAlchemy and Python types #}
+{%- set type_map = {
+    "uuid": ("UUID", "uuid.UUID"),
+    "string": ("String", "str"),
+    "Array2dFloat": ("JSONB", "JSONB"),
+    "integer": ("Integer", "int"),
+    "float": ("Float", "float"),
+    "boolean": ("Boolean", "bool"),
+    "date": ("DateTime(timezone=True)", "datetime.datetime"),
+} %}
+{%- macro getPyType(field) -%}
+  {%- if field.is_enum -%}
+    {{field.type}}
+  {%- elif field.type in type_map -%}
+    {{ type_map[field.type][1] }}
+  {%- endif -%}
+{%- endmacro %}
+{%- macro getSaType(field) -%}
+  {%- if field.is_enum -%}
+    Enum({{field.type}}, native_enum=False)
+  {%- elif field.type in type_map -%}
+    {{ type_map[field.type][0] }}
+  {%- endif -%}
+{%- endmacro %}
+
     {%- for attr in cls.owned_fields %}
         {%- if attr.type == "uuid" %}
-    {{attr.name}}: Mapped[uuid.UUID] = mapped_column({%- if attr.inverse %}ForeignKey("{{attr.inverse}}"){%- else %}UUID{%- endif %}, nullable={{ "False" if attr.required else "True"}}, primary_key={{ "True" if attr.identifier else "False"}}{%- if attr.indexed%}, index=True{%- endif %})
-        {%- elif attr.type == "string" %}
-    {{attr.name}}: Mapped[str] = mapped_column(String, nullable={{ "False" if attr.required else "True"}}{%- if attr.indexed%}, index=True{%- endif %})
-        {%- elif attr.type == "Array2dFloat" %}
-    {{attr.name}}: Mapped[JSONB] = mapped_column(JSONB, nullable={{ "False" if attr.required else "True"}})
-        {%- elif attr.type == "integer" %}
-    {{attr.name}}: Mapped[int] = mapped_column(Integer, nullable={{ "False" if attr.required else "True"}}{%- if attr.indexed%}, index=True{%- endif %})
-        {%- elif attr.type == "float" %}
-    {{attr.name}}: Mapped[int] = mapped_column(Float, nullable={{ "False" if attr.required else "True"}}{%- if attr.indexed%}, index=True{%- endif %})
-        {%- elif attr.is_enum %}
-    {{attr.name}}: Mapped[{{attr.type}}] = mapped_column(Enum({{attr.type}}, native_enum=False), nullable={{ "False" if attr.required else "True"}}{%- if attr.indexed%}, index=True{%- endif %})
-        {%- elif attr.type == "boolean" %}
-    {{attr.name}}: Mapped[bool] = mapped_column(Boolean, nullable={{ "False" if attr.required else "True"}}{%- if attr.indexed%}, index=True{%- endif %})
-        {%- elif attr.type == "date" %}
-    {{attr.name}}: Mapped[datetime.datetime] = mapped_column(DateTime(timezone=True), nullable={{ "False" if attr.required else "True"}}{%- if attr.indexed%}, index=True{%- endif %})
+    {{attr.name}}: Mapped[{{ getPyType(attr) }}] = mapped_column({%- if attr.inverse %}ForeignKey("{{attr.inverse}}"){%- else %}UUID{%- endif %}, {{ getStandardParameters(attr) }})
+        {%- elif getSaType(attr) != "" %}
+    {{attr.name}}: Mapped[{{ getPyType(attr) }}] = mapped_column({{ getSaType(attr) }}, {{ getStandardParameters(attr) }})
         {%- else %}
             {%- if attr.is_cascade_delete -%}
                 {%- if attr.type == "File" -%}
@@ -83,15 +108,10 @@ class {{cls.name}}(Entity):
         {{cascade}}
     )
             {%- else %}
-    {{attr.name}}_id: Mapped[uuid.UUID] = mapped_column(
-        UUID,
-        ForeignKey("{{attr.related_class.snake_name}}.{{attr.related_class.identifier}}"),
-        nullable={{"False" if attr.required else "True"}},
-        {%- if attr.identifier %}
-        primary_key=True,
-        {%- else %}
-        index=True,
-        {%- endif %}
+    {{attr.name}}_id: Mapped[{{ getPyType(attr.related_class.identifier) }}] = mapped_column(
+        {{ getSaType(attr.related_class.identifier) }},
+        ForeignKey("{{attr.related_class.snake_name}}.{{attr.related_class.identifier.name}}"),
+        {{ getStandardParameters(attr) }}
     )
               {%- if attr.type != "Entity" %}
     {{attr.name}}: Mapped["{{attr.type}}"] = relationship(

--- a/platformics/codegen/templates/graphql_api/types/class_name.py.j2
+++ b/platformics/codegen/templates/graphql_api/types/class_name.py.j2
@@ -7,6 +7,88 @@ Make changes to the template codegen/templates/graphql_api/types/class_name.py.j
 
 # ruff: noqa: E501 Line too long
 
+{%- set type_map = {
+    "uuid": "strawberry.ID",
+    "string": "str",
+    "Array2dFloat": "List[List[float]]",
+    "integer": "int",
+    "float": "float",
+    "boolean": "bool",
+    "date": "datetime.datetime",
+} %}
+{# Macro to print field description argument #}
+{%- macro getDescription(attr, action) -%}
+= strawberry.field(description={{ attr.description }}{%- if action == "Update" or not attr.required -%}, default=None{%- endif -%})
+{%- endmacro %}
+
+{# Macro for mutations to output X or Optional[X] #}
+{% macro getTypeMutation(action, type, required) -%}
+    {%- if action == "Create" and required -%}
+      {{ type }}
+    {%- else -%}
+      Optional[{{ type }}]
+    {%- endif -%}
+{%- endmacro %}
+{# Macro to generate comparators for types #}
+{%- macro getComparators(field) -%}
+  {%- if field.type == "uuid" -%}
+    UUIDComparators
+  {%- elif field.type == "string" -%}
+    StrComparators
+  {%- elif field.type == "Array2dFloat" -%}
+    JSONB
+  {%- elif field.type == "integer" -%}
+    IntComparators
+  {%- elif field.type == "float" -%}
+    FloatComparators
+  {%- elif field.is_enum -%}
+    EnumComparators[{{ field.type }}]
+  {%- elif field.type == "boolean" -%}
+    BoolComparators
+  {%- elif field.type == "date" -%}
+    DatetimeComparators
+  {%- elif field.inverse -%}
+    Annotated["{{ field.type }}WhereClause", strawberry.lazy("graphql_api.types.{{ field.related_class.snake_name }}")]
+  {%- elif field.inverse -%}
+  {%- endif -%}
+{%- endmacro %}
+{# Macro to output "X" or "Optional[X]" #}
+{% macro getType(type, required) -%}
+    {%- if required %} {{ type }}
+    {%- else %} Optional[{{ type }}]
+    {%- endif %}
+{%- endmacro %}
+{# Macro to output a whole field definition for standard types #}
+{% macro getFieldDef(attr) -%}
+    {{ attr.name }}: {% if not attr.required -%}Optional[{%- endif -%}{{ type_map[attr.type] }}{%- if not attr.required -%}]{%- endif %} {{ getDescription(attr, "read") }}
+{%- endmacro %}
+{# Macro to generate mutation input fields #}
+{% macro getInputFields(action, fields) -%}
+    {%- for attr in fields %}
+        {%- if attr.type == "string" %}
+    {{ attr.name }}: {{ getTypeMutation(action, "str", attr.required) }} {{ getDescription(attr, action) }}
+        {%- elif attr.type == "uuid" %}
+    {{ attr.name }}: {{ getTypeMutation(action, "strawberry.ID", attr.required) }} {{ getDescription(attr, action) }}
+        {%- elif attr.type == "Array2dFloat" %}
+    {{ attr.name }}: {{ getTypeMutation(action, "List[List[float]]", attr.required) }} {{ getDescription(attr, action) }}
+        {%- elif attr.is_enum %}
+    {{ attr.name }}: {{ getTypeMutation(action, attr.type, attr.required) }} {{ getDescription(attr, action) }}
+        {%- elif attr.type == "integer" %}
+    {{ attr.name }}: {{ getTypeMutation(action, "int", attr.required) }} {{ getDescription(attr, action) }}
+        {%- elif attr.type == "float" %}
+    {{ attr.name }}: {{ getTypeMutation(action, "float", attr.required) }} {{ getDescription(attr, action) }}
+        {%- elif attr.type == "boolean" %}
+    {{ attr.name }}: {{ getTypeMutation(action, "bool", attr.required) }} {{ getDescription(attr, action) }}
+        {%- elif attr.type == "date" %}
+    {{ attr.name }}: {{ getTypeMutation(action, "datetime.datetime", attr.required) }} {{ getDescription(attr, action) }}
+        {%- elif attr.type == "File" %}
+    {{ attr.name }}_id: {{ getTypeMutation(action, "strawberry.ID", attr.required) }} {{ getDescription(attr, action) }}
+        {%- elif attr.is_entity and not attr.is_virtual_relationship %} {# Don't include multivalued fields, only fields where we can update an ID #}
+    {{ attr.name }}_id: {{ getTypeMutation(action, "strawberry.ID", attr.required) }} {{ getDescription(attr, action) }}
+        {%- endif %}
+    {%- endfor %}
+{%- endmacro %}
+
 {% set related_fields = cls.related_fields | unique(attribute='related_class.name') | list %}
 {% set ignored_fields = ["File", "Entity", cls.name] %}
 
@@ -182,7 +264,11 @@ We can extend that list as we gather more use cases from the FE team.
 """
 @strawberry.input
 class {{ cls.name }}WhereClauseMutations(TypedDict):
-    id: UUIDComparators | None
+    {%- for attr in cls.visible_fields %}
+        {%- if attr.identifier %}
+    {{ attr.name }}: {{ getComparators(attr) }} | None
+        {%- endif %}
+    {%- endfor %}
 
 
 """
@@ -191,24 +277,11 @@ Supported WHERE clause attributes
 @strawberry.input
 class {{ cls.name }}WhereClause(TypedDict):
     {%- for attr in cls.visible_fields %}
-        {%- if attr.type == "uuid" %}
-    {{ attr.name }}: Optional[UUIDComparators] | None
-        {%- elif attr.type == "string" %}
-    {{ attr.name }}: Optional[StrComparators] | None
-        {%- elif attr.is_enum %}
-    {{ attr.name }}: Optional[EnumComparators[{{ attr.type }}]] | None
-        {%- elif attr.type == "integer" %}
-    {{ attr.name }}: Optional[IntComparators] | None
-        {%- elif attr.type == "float" %}
-    {{ attr.name }}: Optional[FloatComparators] | None
-        {%- elif attr.type == "boolean" %}
-    {{ attr.name }}: Optional[BoolComparators] | None
-        {%- elif attr.type == "date" %}
-    {{ attr.name }}: Optional[DatetimeComparators] | None
-        {%- elif attr.inverse %}
-    {{ attr.name }}: Optional[Annotated["{{ attr.type }}WhereClause", strawberry.lazy("graphql_api.types.{{ attr.related_class.snake_name }}")]] | None
-        {%- elif attr.type == cls.name %}
-    {{ attr.name }}_id: Optional[UUIDComparators] | None
+        {%- if attr.type == cls.name %}
+    {{ attr.name }}_id: Optional[{{ getComparators(attr.related_class.identifier) }}] | None
+        {%- elif attr.type == "File" %}
+        {%- else %}
+    {{ attr.name }}: Optional[{{ getComparators(attr) }}] | None
         {%- endif %}
     {%- endfor %}
 
@@ -227,12 +300,6 @@ class {{ cls.name }}OrderByClause(TypedDict):
         {%- endif %}
     {%- endfor %}
 
-{# Macro to output "X" or "Optional[X]" #}
-{% macro getType(type, required) -%}
-    {%- if required %} {{ type }}
-    {%- else %} Optional[{{ type }}] = None
-    {%- endif %}
-{%- endmacro %}
 
 """
 Define {{ cls.name }} type
@@ -240,22 +307,8 @@ Define {{ cls.name }} type
 @strawberry.type
 class {{ cls.name }}(EntityInterface):
     {%- for attr in cls.visible_fields %}
-        {%- if attr.type == "uuid" %}
-    {{ attr.name }}: {{ getType("strawberry.ID", attr.required) }}
-        {%- elif attr.type == "string" %}
-    {{ attr.name }}: {{ getType("str", attr.required) }}
-        {%- elif attr.type == "Array2dFloat" %}
-    {{ attr.name }}: {{ getType("List[List[float]]", attr.required) }}
-        {%- elif attr.is_enum %}
-    {{ attr.name }}: {{ getType(attr.type, attr.required) }}
-        {%- elif attr.type == "integer" %}
-    {{ attr.name }}: {{ getType("int", attr.required) }}
-        {%- elif attr.type == "float" %}
-    {{ attr.name }}: {{ getType("float", attr.required) }}
-        {%- elif attr.type == "boolean" %}
-    {{ attr.name }}: {{ getType("bool", attr.required) }}
-        {%- elif attr.type == "date" %}
-    {{ attr.name }}: {{ getType("datetime.datetime", attr.required) }}
+        {%- if attr.is_enum %}
+    {{ attr.name }}: {{ getType(attr.type, attr.required) }} {{ getDescription(attr) }}
         {%- elif attr.type == "File" %}
     {{ attr.name }}_id: Optional[strawberry.ID]
     {{ attr.name }}: Optional[Annotated["File", strawberry.lazy("platformics.graphql_api.files")]] = load_files_from("{{ attr.name }}")  # type: ignore
@@ -266,6 +319,8 @@ class {{ cls.name }}(EntityInterface):
             {%- if attr.multivalued %}
     {{ attr.name }}_aggregate : Optional[Annotated["{{ attr.related_class.name }}Aggregate", strawberry.lazy("graphql_api.types.{{ attr.related_class.snake_name }}")]] = load_{{ attr.related_class.snake_name }}_aggregate_rows  # type:ignore
             {%- endif %}
+        {%- else %}
+    {{ getFieldDef(attr) }}
         {%- endif %}
     {%- endfor %}
 
@@ -291,9 +346,9 @@ Define columns that support numerical aggregations
 class {{ cls.name }}NumericalColumns:
     {%- for attr in cls.numeric_fields %}
         {%- if attr.type == "integer" %}
-    {{ attr.name }}: {{ getType("int", False) }}
+    {{ attr.name }}: {{ getType("int", False) }} = None
         {%- elif attr.type == "float" %}
-    {{ attr.name }}: {{ getType("float", False) }}
+    {{ attr.name }}: {{ getType("float", False) }} = None
         {%- endif %}
     {%- endfor %}
 {%- endif %}
@@ -305,13 +360,13 @@ Define columns that support min/max aggregations
 class {{ cls.name }}MinMaxColumns:
     {%- for attr in cls.visible_fields %}
         {%- if attr.type == "integer" %}
-    {{ attr.name }}: {{ getType("int", False) }}
+    {{ attr.name }}: {{ getType("int", False) }} = None
         {%- elif attr.type == "float" %}
-    {{ attr.name }}: {{ getType("float", False) }}
+    {{ attr.name }}: {{ getType("float", False) }} = None
         {%- elif attr.type == "string" %}
-    {{ attr.name }}: {{ getType("str", False) }}
+    {{ attr.name }}: {{ getType("str", False) }} = None
         {%- elif attr.type == "date" %}
-    {{ attr.name }}: {{ getType("datetime.datetime", False) }}
+    {{ attr.name }}: {{ getType("datetime.datetime", False) }} = None
         {%- endif %}
     {%- endfor %}
 
@@ -356,38 +411,6 @@ class {{ cls.name }}Aggregate:
 Mutation types
 ------------------------------------------------------------------------------
 """
-{# Macro for mutations to output X or Optional[X] #}
-{% macro getTypeMutation(action, type, required) -%}
-    {%- if action == "Create" and required %} {{ type }}
-    {%- else %} Optional[{{ type }}] = None
-    {%- endif %}
-{%- endmacro %}
-
-{% macro getInputFields(action, fields) -%}
-    {%- for attr in fields %}
-        {%- if attr.type == "string" %}
-    {{ attr.name }}: {{ getTypeMutation(action, "str", attr.required) }}
-        {%- elif attr.type == "uuid" %}
-    {{ attr.name }}: {{ getTypeMutation(action, "strawberry.ID", attr.required) }}
-        {%- elif attr.type == "Array2dFloat" %}
-    {{ attr.name }}: {{ getTypeMutation(action, "List[List[float]]", attr.required) }}
-        {%- elif attr.is_enum %}
-    {{ attr.name }}: {{ getTypeMutation(action, attr.type, attr.required) }}
-        {%- elif attr.type == "integer" %}
-    {{ attr.name }}: {{ getTypeMutation(action, "int", attr.required) }}
-        {%- elif attr.type == "float" %}
-    {{ attr.name }}: {{ getTypeMutation(action, "float", attr.required) }}
-        {%- elif attr.type == "boolean" %}
-    {{ attr.name }}: {{ getTypeMutation(action, "bool", attr.required) }}
-        {%- elif attr.type == "date" %}
-    {{ attr.name }}: {{ getTypeMutation(action, "datetime.datetime", attr.required) }}
-        {%- elif attr.type == "File" %}
-    {{ attr.name }}_id: {{ getTypeMutation(action, "strawberry.ID", attr.required) }}
-        {%- elif attr.is_entity and not attr.is_virtual_relationship %} {# Don't include multivalued fields, only fields where we can update an ID #}
-    {{ attr.name }}_id: {{ getTypeMutation(action, "strawberry.ID", attr.required) }}
-        {%- endif %}
-    {%- endfor %}
-{%- endmacro %}
 
 {# Generate Create and Update Strawberry input types #}
 {%- if cls.create_fields %}
@@ -545,6 +568,8 @@ async def create_{{ cls.snake_name }}(
         raise PlatformicsError("Unauthorized: Cannot create entity")
 
     session.add(new_entity)
+    await session.flush()
+    await session.refresh(new_entity)
     await session.commit()
     return new_entity
 {%- endif %}
@@ -614,6 +639,8 @@ async def update_{{ cls.snake_name }}(
     if not authz_client.can_update(entity, principal):
         raise PlatformicsError("Unauthorized: Cannot access new collection")
 
+    await session.flush()
+    [await session.refresh(entity) for entity in entities]
     await session.commit()
     return entities
 {%- endif %}

--- a/test_app/schema/schema.yaml
+++ b/test_app/schema/schema.yaml
@@ -348,3 +348,42 @@ classes:
     annotations:
       mutable: false
       plural: ImmutableTypes
+
+  AutoUpdatedType:
+    is_a: Entity
+    mixins:
+      - EntityMixin
+    attributes:
+      name:
+        range: string
+        required: true
+      auto_inc_field:
+        range: integer
+        annotations:
+          auto_increment: true
+      default_value:
+        range: string
+        ifabsent: "ifabsent_value"
+      default_sa_func:
+        range: date
+        annotations:
+          default_sa_function: now()
+      default_callable:
+        range: date
+        annotations:
+          default_value_callable: datetime.datetime.now
+      onupdate_callable:
+        range: date
+        annotations:
+          onupdate: datetime.datetime.now
+      onupdate_sa_func:
+        range: date
+        annotations:
+          onupdate_sa_function: now()
+      combo_field:
+        range: date
+        annotations:
+          default_sa_function: now()
+          onupdate_sa_function: now()
+    annotations:
+      plural: AutoUpdatedTypes

--- a/test_app/schema/schema.yaml
+++ b/test_app/schema/schema.yaml
@@ -355,6 +355,7 @@ classes:
       - EntityMixin
     attributes:
       name:
+        description: This is a field description
         range: string
         required: true
       auto_inc_field:

--- a/test_app/tests/test_auto_values.py
+++ b/test_app/tests/test_auto_values.py
@@ -1,0 +1,180 @@
+"""
+Test basic queries and mutations
+"""
+
+import datetime
+import pytest
+from platformics.database.connect import SyncDB
+from conftest import GQLTestClient, SessionStorage
+from test_infra.factories.sample import SampleFactory
+
+date_now = datetime.datetime.now()
+
+
+@pytest.mark.asyncio
+async def test_graphql_query(
+    sync_db: SyncDB,
+    gql_client: GQLTestClient,
+) -> None:
+    """
+    Test that we can only fetch samples from the database that we have access to
+    """
+    user_id = 12345
+    secondary_user_id = 67890
+    project_id = 123
+
+    # Create mock data
+    with sync_db.session() as session:
+        SessionStorage.set_session(session)
+        SampleFactory.create_batch(
+            2,
+            collection_location="San Francisco, CA",
+            collection_date=date_now,
+            owner_user_id=user_id,
+            collection_id=project_id,
+        )
+        SampleFactory.create_batch(
+            6,
+            collection_location="Mountain View, CA",
+            collection_date=date_now,
+            owner_user_id=user_id,
+            collection_id=project_id,
+        )
+        SampleFactory.create_batch(
+            4,
+            collection_location="Phoenix, AZ",
+            collection_date=date_now,
+            owner_user_id=secondary_user_id,
+            collection_id=9999,
+        )
+
+    # Fetch all samples
+    query = """
+        query MyQuery {
+            samples {
+                id,
+                collectionLocation
+            }
+        }
+    """
+    output = await gql_client.query(query, user_id=user_id, member_projects=[project_id])
+    locations = [sample["collectionLocation"] for sample in output["data"]["samples"]]
+    assert "San Francisco, CA" in locations
+    assert "Mountain View, CA" in locations
+    assert "Phoenix, AZ" not in locations
+
+
+@pytest.mark.asyncio
+async def test_autoupdate_fields(gql_client: GQLTestClient, sync_db: SyncDB) -> None:
+    """
+    Validate that can only create/modify samples in collections the user has access to
+    """
+    with sync_db.session() as session:
+        SessionStorage.set_session(session)
+        SampleFactory.create_batch(2, collection_location="San Francisco, CA", owner_user_id=10, collection_id=10)
+
+    project_id = 123
+    projects_allowed = [project_id]
+    query = f"""
+        mutation createAuto {{
+            createAutoUpdatedType(input: {{
+                name: "Test row",
+                collectionId: {project_id},
+            }}) {{
+                id,
+                name,
+                autoIncField,
+                defaultValue,
+                defaultSaFunc,
+                defaultCallable,
+                onupdateCallable,
+                onupdateSaFunc,
+                comboField
+            }}
+        }}
+    """
+    output = await gql_client.query(query, member_projects=projects_allowed)
+    assert "errors" not in output
+
+    row = output["data"]["createAutoUpdatedType"]
+    assert row["name"] == "Test row"
+    assert row["defaultSaFunc"].startswith(datetime.datetime.now().isoformat()[:11])
+    assert row["defaultCallable"].startswith(datetime.datetime.now().isoformat()[:11])
+    assert row["comboField"].startswith(datetime.datetime.now().isoformat()[:11])
+    assert row["onupdateCallable"] is None
+    assert row["onupdateSaFunc"] is None
+    assert row["defaultValue"] == "ifabsent_value"
+
+    new_name = "updated test row"
+    identifier = row["id"]
+    query = f"""
+        mutation modifyQuery {{
+            updateAutoUpdatedType(
+                input: {{
+                    name: "{new_name}",
+                    defaultValue: "updated_default"
+                }}
+                where: {{
+                    id: {{ _eq: "{identifier}" }}
+                }}
+            ) {{
+                id,
+                name,
+                autoIncField,
+                defaultValue,
+                defaultSaFunc,
+                defaultCallable,
+                onupdateCallable,
+                onupdateSaFunc,
+                comboField
+            }}
+        }}
+    """
+    output = await gql_client.query(query, member_projects=projects_allowed)
+    assert "errors" not in output
+    row = output["data"]["updateAutoUpdatedType"][0]
+    assert row["name"] == new_name
+
+    assert row["defaultSaFunc"].startswith(datetime.datetime.now().isoformat()[:11])
+    assert row["defaultCallable"].startswith(datetime.datetime.now().isoformat()[:11])
+    assert row["comboField"].startswith(datetime.datetime.now().isoformat()[:11])
+    assert row["onupdateCallable"].startswith(datetime.datetime.now().isoformat()[:11])
+    assert row["onupdateSaFunc"].startswith(datetime.datetime.now().isoformat()[:11])
+    assert row["onupdateCallable"] > row["defaultCallable"]
+    assert row["onupdateSaFunc"] > row["defaultSaFunc"]
+    assert row["defaultValue"] == "updated_default"
+
+    # Test deletion
+    query = f"""
+        mutation deleteOne {{
+            deleteAutoUpdatedType(
+                where: {{ id: {{ _eq: "{identifier}" }} }}
+            ) {{
+                id,
+                name,
+                autoIncField,
+                defaultValue,
+                defaultSaFunc,
+                defaultCallable,
+                onupdateCallable,
+                onupdateSaFunc
+            }}
+        }}
+    """
+    output = await gql_client.query(query, member_projects=projects_allowed)
+    assert "errors" not in output
+    assert len(output["data"]["deleteAutoUpdatedType"]) == 1
+    assert output["data"]["deleteAutoUpdatedType"][0]["id"] == identifier
+    assert output["data"]["deleteAutoUpdatedType"][0]["name"] == new_name
+
+    # Try to fetch sample now that it's deleted
+    query = f"""
+        query getDeleted {{
+            autoUpdatedTypes ( where: {{ id: {{ _eq: "{identifier}" }} }}) {{
+                id,
+                name
+            }}
+        }}
+    """
+    output = await gql_client.query(query, member_projects=projects_allowed)
+    assert output["data"]["autoUpdatedTypes"] == []

--- a/test_app/tests/test_field_descriptions.py
+++ b/test_app/tests/test_field_descriptions.py
@@ -1,0 +1,38 @@
+"""
+Test that field descriptions are present in the GQL API
+"""
+
+import datetime
+import pytest
+from conftest import GQLTestClient
+
+date_now = datetime.datetime.now()
+
+
+@pytest.mark.asyncio
+async def test_field_description(
+    gql_client: GQLTestClient,
+) -> None:
+    """
+    Test that we can only fetch samples from the database that we have access to
+    """
+
+    # Fetch all samples
+    query = """
+       {
+         __type(name: "AutoUpdatedType") {
+           name
+           fields {
+             name
+             description
+          }
+        }
+      }
+    """
+    output = await gql_client.query(query, user_id=999, member_projects=[999])
+    fields = output["data"]["__type"]["fields"]
+    field = {}
+    for field in fields:
+        if field["name"] == "name":
+            break
+    assert field["description"] == "This is a field description"


### PR DESCRIPTION
Sorry, this is stacked on top of the previous PR's.

This PR adds a few features:
- Ability to add descriptions to fields in the schema, and have those descriptions exposed via the GQL API
- Ability to add a `skip_codegen` annotation to a schema class or enum to have it omitted from the generated output
- Ability to set default field values (either computed by the db or python callables) for db models