### PR TITLE
fix: update import in env.py

### DIFF
--- a/platformics/codegen/templates/database/migrations/env.py.j2
+++ b/platformics/codegen/templates/database/migrations/env.py.j2
@@ -3,7 +3,7 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import create_engine
 
-from database.models import meta
+from platformics.database.models import meta
 from platformics.settings import CLISettings
 
 # this is the Alembic Config object, which provides


### PR DESCRIPTION
This import causes a race condition when running `make apply-schema-changes`. The modified import doesn't rely on the `model` directory, so it will fix the race condition.