### PR TITLE
chore: Remove override of api settings in get_app

### DIFF
--- a/platformics/graphql_api/setup.py
+++ b/platformics/graphql_api/setup.py
@@ -56,7 +56,6 @@ def get_app(settings: APISettings, schema: strawberry.Schema, db_module: typing.
     """
     File.set_settings(settings)
     File.set_s3_client(get_s3_client(settings))
-    settings = APISettings.model_validate({})  # Workaround for https://github.com/pydantic/pydantic/issues/3753
 
     title = settings.SERVICE_NAME
     graphql_app: GraphQLRouter = GraphQLRouter(schema, context_getter=get_context)


### PR DESCRIPTION
* I think settings should be passed into this function, so we shouldn't be recreating the variable here
* This will also help with trying to extend APISettings from the generated app