### PR TITLE
fix: Don't create migration if there are no schema changes

### DIFF
--- a/platformics/codegen/templates/database/migrations/env.py.j2
+++ b/platformics/codegen/templates/database/migrations/env.py.j2
@@ -56,11 +56,19 @@ def run_migrations_online() -> None:
     settings = CLISettings.model_validate({})
     connectable = create_engine(settings.SYNC_DB_URI)
 
+    def process_revision_directives(context, revision, directives):
+        if config.cmd_opts.autogenerate:
+            script = directives[0]
+            if script.upgrade_ops.is_empty():
+                directives[:] = []
+                print('No changes in schema detected.')
+
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
             target_metadata=target_metadata,
             include_schemas=True,
+            process_revision_directives = process_revision_directives,
         )
 
         with context.begin_transaction():


### PR DESCRIPTION
* Copied from: https://stackoverflow.com/questions/70203927/how-to-prevent-alembic-revision-autogenerate-from-making-revision-file-if-it-h
